### PR TITLE
Restore compact thermostat card visuals

### DIFF
--- a/src/components/infoItem.ts
+++ b/src/components/infoItem.ts
@@ -260,7 +260,7 @@ export default function renderInfoItem({
           @click=${canOpenEntity ? () => openEntityPopover(entityId) : null}
         ></ha-icon>
       `
-    : ` ${heading}: `
+    : heading
 
   return html`<div
       class=${headingClasses}

--- a/src/config/header.ts
+++ b/src/config/header.ts
@@ -30,7 +30,7 @@ export const CLIMATE_COOLING_STATE_ICONS = {
   cooling: 'mdi:snowflake',
   fan: 'mdi:fan',
   heating: 'mdi:radiator',
-  idle: 'mdi:air-conditioner',
+  idle: 'mdi:thermostat',
   on: 'mdi:air-conditioner',
   off: 'mdi:air-conditioner',
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,7 +13,7 @@
   --st-default-mode-transition: 200ms ease;
   --st-motion-ease: cubic-bezier(0.2, 0, 0, 1);
   --st-control-icon-size: var(--st-font-size-xl, 32px);
-  --st-header-icon-size: var(--st-font-size-header-icon, 26px);
+  --st-header-icon-size: var(--st-font-size-header-icon, 24px);
   --st-preset-icon-size: var(
     --st-font-size-preset-icon,
     var(--ha-font-size-xl, 20px)
@@ -42,15 +42,15 @@ ha-card {
 
   padding-bottom: calc(var(--st-spacing, var(--st-default-spacing)) * 2);
 
-  --auto-color: green;
-  --heat_cool-color: springgreen;
-  --cool-color: #2b9af9;
-  --heat-color: #ff8100;
+  --auto-color: #66bb6a;
+  --heat_cool-color: #4ade80;
+  --cool-color: #60a5fa;
+  --heat-color: #fb923c;
   --manual-color: #44739e;
   --on-color: var(--primary-color);
   --off-color: #8a8a8a;
   --fan_only-color: #8a8a8a;
-  --dry-color: #efbd07;
+  --dry-color: #facc15;
   --st-mode-surface-background: color-mix(
     in srgb,
     var(--primary-text-color) 14%,
@@ -300,6 +300,7 @@ ha-card.loading {
   }
   &.with-labels {
     grid: auto-flow / auto auto;
+    column-gap: 8px;
     place-items: start;
   }
 }
@@ -322,9 +323,9 @@ ha-card.loading {
   white-space: normal;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  justify-self: end;
-  text-align: right;
+  justify-content: flex-start;
+  justify-self: start;
+  text-align: left;
   transition:
     color 180ms var(--st-motion-ease),
     filter 180ms var(--st-motion-ease);
@@ -861,7 +862,7 @@ ha-card.cooling .header__icon-wrap::before {
   transition: none;
 }
 ha-card:not(.standard-visuals) .mode-item.active .mode-icon {
-  color: var(--st-mode-active-icon-color);
+  color: var(--st-mode-active-color, var(--text-primary-color));
 }
 .mode-item .mode-icon {
   transition:

--- a/src/test/parseHeader.test.ts
+++ b/src/test/parseHeader.test.ts
@@ -97,6 +97,26 @@ test('uses action-specific cooling icon for active cooling climate entities', ()
   )
 })
 
+test('uses a neutral thermostat icon for idle cooling-capable climate entities', () => {
+  const result = parseHeader(
+    {},
+    {
+      entity_id: 'climate.swing_ac',
+      state: 'heat_cool',
+      attributes: {
+        friendly_name: 'Swing AC',
+        hvac_action: 'idle',
+        hvac_modes: ['off', 'heat', 'cool', 'heat_cool'],
+      },
+    },
+    hass
+  )
+
+  expect(result && typeof result.icon === 'object' && result.icon.idle).toBe(
+    'mdi:thermostat'
+  )
+})
+
 test('keeps heat-only climate fallback as radiator', () => {
   const result = parseHeader(
     {},

--- a/src/test/renderInfoItem.test.ts
+++ b/src/test/renderInfoItem.test.ts
@@ -36,7 +36,7 @@ test('render into dom', () => {
   const heading = document.body.querySelector('div').textContent
   const value = document.body.querySelector('div:last-child').textContent
 
-  expect(heading.trim()).toBe(`${spec.heading}:`)
+  expect(heading.trim()).toBe(spec.heading)
   expect(value.trim()).toBe(spec.value)
 })
 
@@ -179,6 +179,25 @@ test('entity row template can format state.raw like v3 sensors', () => {
 
   const value = container.querySelector('.entity-value')?.textContent
   expect(value?.trim()).toBe('20')
+})
+
+test('entity row text headings render without a separator suffix', () => {
+  const result = renderInfoItem({
+    hide: false,
+    hass: {},
+    state: '73',
+    details: {
+      heading: 'Currently',
+    },
+  })
+
+  const container = document.createElement('div')
+  document.body.replaceChildren(container)
+  render(result, container)
+
+  const heading = container.querySelector('.entity-heading')?.textContent
+  expect(heading?.trim()).toBe('Currently')
+  expect(heading).not.toContain(':')
 })
 
 test('entity row template can use an attribute value as a top-level variable', () => {

--- a/src/test/styles.test.ts
+++ b/src/test/styles.test.ts
@@ -60,7 +60,7 @@ test('card body cannot overflow wrapper overlay width', () => {
   expect(styles).toContain('minmax(max-content, 1fr)')
 })
 
-test('entity table labels can wrap while values stay on one line', () => {
+test('entity table labels keep v3-style column alignment', () => {
   const styles = fs.readFileSync(
     path.join(__dirname, '..', 'styles.css'),
     'utf8'
@@ -70,11 +70,12 @@ test('entity table labels can wrap while values stay on one line', () => {
   const headingRule = styles.match(/\.entity-heading\s*\{[^}]*\}/)?.[0] ?? ''
   const valueRule = styles.match(/\.entity-value\s*\{[^}]*\}/)?.[0] ?? ''
 
-  expect(tableLabelsRule).toContain(
-    'grid: auto-flow / auto auto'
-  )
+  expect(tableLabelsRule).toContain('grid: auto-flow / auto auto')
+  expect(tableLabelsRule).toContain('column-gap: 8px')
   expect(headingRule).toContain('min-width: 0')
   expect(headingRule).toContain('white-space: normal')
+  expect(headingRule).toContain('justify-self: start')
+  expect(headingRule).toContain('text-align: left')
   expect(valueRule).toContain('min-width: max-content')
   expect(valueRule).toContain('white-space: nowrap')
 })
@@ -108,7 +109,7 @@ test('standard visuals keep upstream-style header icon sizing', () => {
   expect(standardHeaderIconRule).toContain('height: 24px')
 })
 
-test('layout compatibility fixes do not retune semantic colors or icons', () => {
+test('layout compatibility fixes use softer semantic colors and a neutral idle icon', () => {
   const styles = fs.readFileSync(
     path.join(__dirname, '..', 'styles.css'),
     'utf8'
@@ -119,18 +120,18 @@ test('layout compatibility fixes do not retune semantic colors or icons', () => 
   )
 
   const baseCardRule = styles.match(/ha-card\s*\{[^}]*\}/)?.[0] ?? ''
-  expect(baseCardRule).toContain('--auto-color: green')
-  expect(baseCardRule).toContain('--heat_cool-color: springgreen')
-  expect(baseCardRule).toContain('--cool-color: #2b9af9')
-  expect(baseCardRule).toContain('--heat-color: #ff8100')
-  expect(baseCardRule).toContain('--dry-color: #efbd07')
-  expect(styles).not.toContain('--auto-color: #66bb6a')
-  expect(styles).not.toContain('--heat_cool-color: #4ade80')
-  expect(styles).not.toContain('--cool-color: #60a5fa')
-  expect(styles).not.toContain('--heat-color: #fb923c')
-  expect(styles).not.toContain('--dry-color: #facc15')
-  expect(headerConfig).toContain("idle: 'mdi:air-conditioner'")
-  expect(headerConfig).not.toContain("idle: 'mdi:thermostat'")
+  expect(baseCardRule).toContain('--auto-color: #66bb6a')
+  expect(baseCardRule).toContain('--heat_cool-color: #4ade80')
+  expect(baseCardRule).toContain('--cool-color: #60a5fa')
+  expect(baseCardRule).toContain('--heat-color: #fb923c')
+  expect(baseCardRule).toContain('--dry-color: #facc15')
+  expect(styles).not.toContain('--auto-color: green')
+  expect(styles).not.toContain('--heat_cool-color: springgreen')
+  expect(styles).not.toContain('--cool-color: #2b9af9')
+  expect(styles).not.toContain('--heat-color: #ff8100')
+  expect(styles).not.toContain('--dry-color: #efbd07')
+  expect(headerConfig).toContain("idle: 'mdi:thermostat'")
+  expect(headerConfig).not.toContain("idle: 'mdi:air-conditioner'")
 })
 
 test('inactive mode buttons use a consistent theme-derived overlay surface', () => {
@@ -155,21 +156,21 @@ test('inactive mode buttons use a consistent theme-derived overlay surface', () 
   )
 })
 
-test('mode colors keep the original simple-thermostat assignments', () => {
+test('mode colors use a softer semantic palette', () => {
   const styles = fs.readFileSync(
     path.join(__dirname, '..', 'styles.css'),
     'utf8'
   )
   const baseCardRule = styles.match(/ha-card\s*\{[^}]*\}/)?.[0] ?? ''
 
-  expect(baseCardRule).toContain('--auto-color: green')
-  expect(baseCardRule).toContain('--heat_cool-color: springgreen')
-  expect(baseCardRule).toContain('--cool-color: #2b9af9')
-  expect(baseCardRule).toContain('--heat-color: #ff8100')
+  expect(baseCardRule).toContain('--auto-color: #66bb6a')
+  expect(baseCardRule).toContain('--heat_cool-color: #4ade80')
+  expect(baseCardRule).toContain('--cool-color: #60a5fa')
+  expect(baseCardRule).toContain('--heat-color: #fb923c')
   expect(baseCardRule).toContain('--manual-color: #44739e')
   expect(baseCardRule).toContain('--off-color: #8a8a8a')
   expect(baseCardRule).toContain('--fan_only-color: #8a8a8a')
-  expect(baseCardRule).toContain('--dry-color: #efbd07')
+  expect(baseCardRule).toContain('--dry-color: #facc15')
   expect(baseCardRule).not.toContain('--state-climate-heat-color')
   expect(baseCardRule).not.toContain('--state-climate-cool-color')
   expect(baseCardRule).not.toContain('--state-climate-heat-cool-color')
@@ -182,9 +183,16 @@ test('active mode backgrounds keep semantic mode colors', () => {
   )
   const activeRule =
     styles.match(/&\.active,\s*&\.active:hover\s*\{[^}]*\}/)?.[0] ?? ''
+  const activeIconRule =
+    styles.match(
+      /ha-card:not\(\.standard-visuals\) \.mode-item\.active \.mode-icon\s*\{[^}]*\}/
+    )?.[0] ?? ''
 
   expect(activeRule).toContain(
     'var(--st-mode-color, var(--primary-color))'
+  )
+  expect(activeIconRule).toContain(
+    'color: var(--st-mode-active-color, var(--text-primary-color))'
   )
 
   const modeColors: Record<string, string> = {
@@ -258,7 +266,7 @@ test('header icons keep their own compact size without shrinking controls', () =
 
   expect(hostRule).toContain('--st-control-icon-size: var(--st-font-size-xl, 32px)')
   expect(hostRule).toContain(
-    '--st-header-icon-size: var(--st-font-size-header-icon, 26px)'
+    '--st-header-icon-size: var(--st-font-size-header-icon, 24px)'
   )
   expect(headerIconRule).toContain('var(--st-header-icon-size)')
   expect(headerIconRule).not.toContain('var(--st-control-icon-size)')


### PR DESCRIPTION
## Summary

Refines the v4 compact thermostat card visuals to better preserve the clean v3-style layout while keeping the current v4 behavior and fixes.

Changes included:

- Render entity row text labels without the hardcoded colon suffix.
- Reduce the default header icon size from `26px` to `24px` so it is less visually dominant in compact cards.
- Restore a v3-like entity table layout with left-aligned labels and an `8px` label/value gap.
- Keep dual-setpoint column layouts from centering or squeezing the entity table.
- Use a clearer active mode icon color on colored active buttons.
- Soften the semantic mode palette so active buttons are less visually harsh.
- Use a neutral `mdi:thermostat` icon for idle cooling-capable climate entities instead of showing the AC icon while idle.

## Why

After the v4 layout fixes, compact climate cards were usable again but still had a few visual regressions from v3:

- labels were rendered as `Currently:` / `Guest:` instead of the cleaner v3 label style,
- the entity rows sat awkwardly in the card body and did not align like the old table,
- the top-left header icon was more prominent than before,
- the active mode icon could become low contrast on colored active buttons,
- the active mode colors were very saturated,
- idle cooling-capable climate entities showed an air-conditioner icon, which implied cooling even when the entity was idle.

This keeps the patch focused on visual compatibility and readability. The branch has been rebased onto the latest upstream `master` after the v4.0.18 layout updates.

## Validation

Ran locally after rebasing onto latest `master`:

- `npm test -- --runInBand`
- `npm run build`

The full test suite passed after the changes.